### PR TITLE
Log uncaught exceptions and keep going

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,3 +1,10 @@
 const ws = require('./ws')
 
+const { error } = console
+
 ws.init()
+
+process.on('uncaughtException', (err) => {
+  error('UNCAUGHT EXCEPTION')
+  error(err)
+})


### PR DESCRIPTION
NOT the recommended method of crash prevention, but the recommended method is deprecated with no alternative solution as of now

https://nodejs.org/api/domain.html#apicontent

closes #80