### PR TITLE
Use localhost as WS address in dev environment

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -27,3 +27,5 @@ services:
         volumes:
             - ./controller:/novelty/controller
             - ./common:/novelty/common
+        environment:
+            - REACT_APP_WS_ADDRESS=ws://localhost:3000


### PR DESCRIPTION
Annoying having to specify this ENV every time you run compose. Is there any use case when localhost wont suffice in development?