### PR TITLE
Clarify goal copy

### DIFF
--- a/game/src/lobby.js
+++ b/game/src/lobby.js
@@ -148,7 +148,7 @@ function createGoalDescription() {
     Entity.getRoot(),
     {
       id: 'goal-description',
-      x:  330,
+      x:  410,
       y:  200,
     },
   )
@@ -156,7 +156,7 @@ function createGoalDescription() {
   const textAsset = Text.show(
     entity,
     {
-      text:  `First to <<  ${score}  >> points wins!`,
+      text:  `First to ${score} points wins!`,
       style: { ...big, fontSize: big.fontSize * getRatio(), fill: 'white' },
     },
   )


### PR DESCRIPTION
closes #230 

väldigt hemmasnickrad highlighting. gjorde en kort ansats att göra det mer seriöst med storlek/färg men det kändes otroligt rörigt att ha 3 nya entities och textfält? finns det nån smidigare lösning som jag inte tänker på?

![screenshot from 2018-07-26 22-36-26](https://user-images.githubusercontent.com/3483136/43287130-5a2e3eee-9124-11e8-9848-596887f12f0b.png)
