### PR TITLE
Lint globally

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint ."
   },
   "author": "",
   "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prettier": "^1.13.7"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "./run_lint.sh"
   },
   "repository": {
     "type": "git",

--- a/run_lint.sh
+++ b/run_lint.sh
@@ -1,0 +1,5 @@
+for dir in backend controller game signaling common; do
+  cd $dir
+  npm run lint
+  cd -
+done

--- a/signaling/package.json
+++ b/signaling/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
+  "scripts": {
+    "lint": "eslint ."
+  },
   "dependencies": {
     "common": "file:../common",
     "webrtc-adapter": "^6.3.0"


### PR DESCRIPTION
closes #203 

mitt preferens hade varit att bara kunna köra `eslint .` på valfri nivå och låta `eslintignore` filtrera bort nonsens. stöter dock på [nån oskön bugg i lodash plugin](https://github.com/jfmengels/eslint-plugin-lodash-fp/issues/51) som sätter käppar i hjulet atm.

~andra~tredjehandsval hade varit att köra nåt smartare mönster, typ `eslint **/src/*.js`, [but no...](https://rymdkraftverk.slack.com/archives/C8YEV5B5E/p1534092380000018)

så voila: ~tredje~andrahandsval: hackigt långtsamt bashscript :tada: 