### PR TITLE
Introduce eventEmitter in game state

### DIFF
--- a/game/src/index.js
+++ b/game/src/index.js
@@ -1,6 +1,7 @@
 import { Game, Entity, Sprite, Key } from 'l1'
 import { EVENTS, prettyId } from 'common'
 import R from 'ramda'
+import { EventEmitter } from 'eventemitter3'
 import signaling from 'signaling'
 import { transitionToGameScene, GAME_EVENTS } from './game'
 import assets from './assets.json'
@@ -31,6 +32,7 @@ export const gameState = {
     playerFinishOrder: [],
     winner:            null,
   },
+  events: new EventEmitter(),
 }
 
 const movePlayer = (pId, direction) => {


### PR DESCRIPTION
På samma sätt som vi har introduceras eventEmitters per player så skulle det vara najs att tillgång till en eventEmitter som har med generella game event.

Mitt use case just nu är att jag skulle vilja lyssna på ROUND_START/ROUND_END för att veta när jag ska börja spela in en ny omgång av metrics och när jag ska spara omgången. 

Vad tycker ni?