### PR TITLE
Restrict usage of global Text since it might be confused for l1 Text

### DIFF
--- a/game/.eslintrc.yml
+++ b/game/.eslintrc.yml
@@ -6,3 +6,6 @@ env:
 rules:
   fp/no-mutating-methods: off
   import/prefer-default-export: off
+  no-restricted-globals:
+    - error
+    - Text


### PR DESCRIPTION
Lintern detekterade inte när man missade att importera Text från level1, då det finns en global variabel som heter samma sak. 

Så denna fix tillåter inte att man använder den globala variabeln Text.