### PR TITLE
Increase heartbeat interval to 3000ms

### DIFF
--- a/signaling/runReceiver.js
+++ b/signaling/runReceiver.js
@@ -13,7 +13,7 @@ const {
   rtcSend,
 } = require('./common')
 
-const HEARTBEAT_INTERVAL = 1000
+const HEARTBEAT_INTERVAL = 3000
 
 const { log } = console
 


### PR DESCRIPTION
@lorentzlasson var tvungna att öka heartbeat för 1000ms var för kort när vi testade med Roberts router. Blev konstant kickade