### PR TITLE
Disable clear canvas for WebGL between frames

### DIFF
--- a/game/src/index.js
+++ b/game/src/index.js
@@ -239,7 +239,7 @@ l1
     debug:   true,
     element: document.getElementById('game'),
     pixi:    {
-      options:  { antialias: true },
+      options:  { antialias: true, clearBeforeRender: false },
       settings: { SCALE_MODE: l1.PIXI.SCALE_MODES.LINEAR },
     },
   })


### PR DESCRIPTION
Since we are using a background and always drawing the background there
is no need for WebGL to clear the canvas before the next frame. The
background will just draw on top of all previous draws anyways.
It's not the biggest performance boost but it's such an easy fix so, why
not.

Source of finding: https://phaser.io/tutorials/advanced-rendering-tutorial/part5