### PR TITLE
Display a message to users on systems that we don't support

### DIFF
--- a/controller/src/components/App.js
+++ b/controller/src/components/App.js
@@ -37,6 +37,7 @@ class App extends Component {
   }
 
   componentDidMount = () => {
+    this.alertIfNoRtc()
     navigator.vibrate(1)
     const gameCode = getLastGameCode()
     this.setState({ gameCode })
@@ -89,6 +90,17 @@ class App extends Component {
 
   displayError = (message) => {
     this.setState({ appState: APP_STATE.LOCKER_ROOM, error: message })
+  }
+
+  alertIfNoRtc = () => {
+    if (typeof RTCPeerConnection === 'undefined') {
+      const message =
+        'Unfortunately the game cannot be played in this browser.' +
+        'See list of supported browsers here: https://caniuse.com/#search=webrtc'
+
+      // eslint-disable-next-line no-alert
+      alert(message)
+    }
   }
 
   gameCodeChange = ({ target: { value } }) =>


### PR DESCRIPTION
closes #436 

lyckades inte hitta nån browser på ubuntu/android som inte stödjer rtc :expressionless: hade höga förhoppningar om [denna](https://play.google.com/store/apps/details?id=com.fevdev.nakedbrowser) men tom den hade rtc :persevere: 

lyckades stänga av featuren i firefox genom denna metod: https://whoer.net/blog/article/how-to-disable-webrtc-in-various-browsers/ men vet inte om det är likvärdigt

nån som vet en browser utan rtc?