### PR TITLE
iOS: Prevent double tap to zoom in LockerRoom and GameLobby

### DIFF
--- a/controller/src/components/GameLobby.js
+++ b/controller/src/components/GameLobby.js
@@ -54,6 +54,8 @@ class GameLobby extends Component {
     return (
       <Container
         backgroundColor={playerColorToBackgroundColor(playerColor)}
+        // Prevent double tap to zoom on iOS
+        onClick={() => {}}
       >
         {
           playerCount > 1

--- a/controller/src/components/LockerRoom.js
+++ b/controller/src/components/LockerRoom.js
@@ -66,7 +66,8 @@ class LockerRoom extends Component {
     const placeholder = 'Code'
 
     return (
-      <Container>
+      // Prevent double tap to zoom on iOS
+      <Container onClick={() => {}}>
         <ContainerColumn>
           <GameCodeInput
             type="text"


### PR DESCRIPTION
closes #439 