### PR TITLE
🐞 Firefox controllers don't disconnect

### DIFF
--- a/signaling/runReceiver.js
+++ b/signaling/runReceiver.js
@@ -70,15 +70,14 @@ const killInitiator = (id) => {
   removeInitiator(id)
 }
 
-const getActiveInitiators = R.filter(R.pipe(
+const isOpen = R.pipe(
   R.view(R.lensPath(['internalChannel', 'readyState'])),
   R.equals(ReadyState.OPEN),
-))
+)
 
 const beatHeart = R.pipe(
-  getActiveInitiators,
   R.forEach((initiator) => {
-    if (initiator.alive) {
+    if (initiator.alive && isOpen(initiator)) {
       rtcSend(
         JSON.stringify,
         initiator.internalChannel,


### PR DESCRIPTION
closes #482

Consider non-open initiators disconnected. Firefox sets readystate to 'stable' but doesn't fire onclose