### PR TITLE
Fix match end text lag

### DIFF
--- a/game/package.json
+++ b/game/package.json
@@ -27,7 +27,7 @@
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "common": "file:../common",
     "eventemitter3": "^3.1.0",
-    "l1": "0.5.3",
+    "l1": "^0.5.4",
     "lodash": "^4.17.10",
     "pixi-particles": "^3.1.0",
     "pixi.js": "^4.8.2",

--- a/game/src/matchEnd.js
+++ b/game/src/matchEnd.js
@@ -97,12 +97,9 @@ const textMovement = text => ({
       speed: 120,
     }),
   },
-  onInit: ({ data }) => {
-    data.originalSize = text.style.fontSize
-  },
   onUpdate: ({ data, counter }) => {
     const scale = data.sine(counter)
-    l1.scaleText(text, data.originalSize * scale)
+    text.scale.set(scale)
   },
 })
 


### PR DESCRIPTION
Texten hackade lite när vi skalade om den med `l1.scaleText`. Denna använder `scale` propertyn på objektet istället, vilket gör texten lite suddigare (knappt märkbart) men hackar inte.