### PR TITLE
Prevent sourcemap from being created for production build in controller

### DIFF
--- a/controller/.env
+++ b/controller/.env
@@ -1,0 +1,1 @@
+GENERATE_SOURCEMAP=false


### PR DESCRIPTION
Source map är default med create-react-app. Vi vill inte läcka affärshemligheter dock...