### PR TITLE
🐞 Cannot run game on Firefox

### DIFF
--- a/signaling/runInitiator.js
+++ b/signaling/runInitiator.js
@@ -122,6 +122,8 @@ const setUpChannel = rtc => ({
     config,
   )
 
+  channel.binaryType = 'arraybuffer'
+
   channel.onerror = R.pipe(
     R.tap(error),
     closeConnections,

--- a/signaling/runReceiver.js
+++ b/signaling/runReceiver.js
@@ -134,6 +134,12 @@ const setUpChannels = (rtc, channelNames, initiator) => {
 
   return new Promise((resolve) => {
     rtc.ondatachannel = ({ channel }) => {
+      // To have consistent binaryType between platforms.
+      // Standard says "blob" should be the standard,
+      // but Chrome uses "arraybuffer" despite this:
+      // https://stackoverflow.com/a/53328431/1859989
+      channel.binaryType = 'arraybuffer'
+
       channel.onopen = () => {
         log(`[Data channel] ${prettyId(initiator.id)} ${channel.label}`)
         openChannels = openChannels.concat([channel])


### PR DESCRIPTION
closes #605 

Chrome som var skurken! https://stackoverflow.com/a/53328431/1859989

Inte dykt extremt djupt i arraybuffer vs blob men läste nånstans att blob passar bättre för större object, så arraybuffer borde vara mer lämpligt för våra dampsmå payloads tänker jag. Sen tror jag även att man måste gå via arraybuffer ([asynkront](https://stackoverflow.com/a/15981017/1859989)) för att få en `Uint8Array`, vilket vi behöver för att deserialisera till protobuff, såatteh... kör på arraybuffer om du inte protesterar högljutt! :upside_down_face: 