### PR TITLE
Fix gyro steering always active after its turned on once

### DIFF
--- a/controller/src/components/Gyro.js
+++ b/controller/src/components/Gyro.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { Event } from 'common'
-import useOrientation from '../hook/useOrientation';
+import useOrientation from '../hook/useOrientation'
 
 const handleOrientation = (enabled, send) => ({ beta }) => {
   if (!enabled) return
@@ -12,7 +12,7 @@ const handleOrientation = (enabled, send) => ({ beta }) => {
 }
 
 const Gyro = ({ enabled, send }) => {
-  useOrientation(handleOrientation(enabled, send));
+  useOrientation(handleOrientation(enabled, send))
 
   return null
 }

--- a/controller/src/hook/useOrientation.js
+++ b/controller/src/hook/useOrientation.js
@@ -1,29 +1,21 @@
 import { useEffect, useRef } from 'react'
 
-export default (callback) => {
-  const savedCallback = useRef();
+export default callback => {
+  const savedCallback = useRef()
 
   // Remember the latest callback
   useEffect(() => {
-    savedCallback.current = callback;
+    savedCallback.current = callback
   }, [callback])
 
   // Set up event listener
   useEffect(() => {
-    const handleOrientation = (e) => {
+    const handleOrientation = e => {
       savedCallback.current(e)
     }
-    window.addEventListener(
-      'deviceorientation',
-      handleOrientation,
-      true,
-    )
+    window.addEventListener('deviceorientation', handleOrientation, true)
     return () => {
-      window.removeEventListener(
-        'deviceorientation',
-        handleOrientation,
-        true,
-      )
+      window.removeEventListener('deviceorientation', handleOrientation, true)
     }
   }, [])
 }


### PR DESCRIPTION
closes #784 

Problemet var att callbacksen som skickades till event listener inte uppdaterades mellan rerenders. Lösningen är att skapa en `custom hook` där man använder en `ref` som är en variabel som går att mutera.